### PR TITLE
Allows per-resource override of update_method

### DIFF
--- a/restapi/api_object.go
+++ b/restapi/api_object.go
@@ -13,28 +13,30 @@ import (
 )
 
 type apiObjectOpts struct {
-	path         string
-	get_path     string
-	post_path    string
-	put_path     string
-	delete_path  string
-	search_path  string
-	debug        bool
-	id           string
-	id_attribute string
-	data         string
+	path          string
+	get_path      string
+	post_path     string
+	put_path      string
+	update_method string
+	delete_path   string
+	search_path   string
+	debug         bool
+	id            string
+	id_attribute  string
+	data          string
 }
 
 type api_object struct {
-	api_client   *api_client
-	get_path     string
-	post_path    string
-	put_path     string
-	delete_path  string
-	search_path  string
-	debug        bool
-	id           string
-	id_attribute string
+	api_client    *api_client
+	get_path      string
+	post_path     string
+	put_path      string
+	update_method string
+	delete_path   string
+	search_path   string
+	debug         bool
+	id            string
+	id_attribute  string
 
 	/* Set internally */
 	data         map[string]interface{} /* Data as managed by the user */
@@ -57,6 +59,10 @@ func NewAPIObject(i_client *api_client, opts *apiObjectOpts) (*api_object, error
 		opts.id_attribute = i_client.id_attribute
 	}
 
+	if opts.update_method == "" {
+		opts.update_method = i_client.update_method
+	}
+
 	if opts.post_path == "" {
 		opts.post_path = opts.path
 	}
@@ -74,17 +80,18 @@ func NewAPIObject(i_client *api_client, opts *apiObjectOpts) (*api_object, error
 	}
 
 	obj := api_object{
-		api_client:   i_client,
-		get_path:     opts.get_path,
-		post_path:    opts.post_path,
-		put_path:     opts.put_path,
-		delete_path:  opts.delete_path,
-		search_path:  opts.search_path,
-		debug:        opts.debug,
-		id:           opts.id,
-		id_attribute: opts.id_attribute,
-		data:         make(map[string]interface{}),
-		api_data:     make(map[string]interface{}),
+		api_client:    i_client,
+		get_path:      opts.get_path,
+		post_path:     opts.post_path,
+		put_path:      opts.put_path,
+		update_method: opts.update_method,
+		delete_path:   opts.delete_path,
+		search_path:   opts.search_path,
+		debug:         opts.debug,
+		id:            opts.id,
+		id_attribute:  opts.id_attribute,
+		data:          make(map[string]interface{}),
+		api_data:      make(map[string]interface{}),
 	}
 
 	if opts.data != "" {
@@ -249,7 +256,7 @@ func (obj *api_object) update_object() error {
 	}
 
 	b, _ := json.Marshal(obj.data)
-	res_str, err := obj.api_client.send_request(obj.api_client.update_method, strings.Replace(obj.put_path, "{id}", obj.id, -1), string(b))
+	res_str, err := obj.api_client.send_request(obj.update_method, strings.Replace(obj.put_path, "{id}", obj.id, -1), string(b))
 	if err != nil {
 		return err
 	}

--- a/restapi/resource_api_object.go
+++ b/restapi/resource_api_object.go
@@ -45,6 +45,11 @@ func resourceRestApi() *schema.Resource {
 				Description: "Defaults to `path/{id}`. The API path that represents where to UPDATE (PUT) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
 				Optional:    true,
 			},
+			"update_method": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Defaults to `update_method` set on the provider. Allows per-resource override of `update_method` (see `update_method` provider config documentation)",
+				Optional:    true,
+			},
 			"destroy_path": &schema.Schema{
 				Type:        schema.TypeString,
 				Description: "Defaults to `path/{id}`. The API path that represents where to DESTROY (DELETE) objects of this type on the API server. The string `{id}` will be replaced with the terraform ID of the object.",
@@ -292,6 +297,9 @@ func buildApiObjectOpts(d *schema.ResourceData) (*apiObjectOpts, error) {
 	}
 	if v, ok := d.GetOk("update_path"); ok {
 		opts.put_path = v.(string)
+	}
+	if v, ok := d.GetOk("update_method"); ok {
+		opts.update_method = v.(string)
 	}
 	if v, ok := d.GetOk("destroy_path"); ok {
 		opts.delete_path = v.(string)


### PR DESCRIPTION
Hi @ahmet2mir,


Add support of update_method in resource configuration. This option could be set initially into provider configuration. We don't want to declare another alias of restapi provider to just change the update method in some resource configuration.

What do you think about this ?